### PR TITLE
control: reply in thread (References: header field)

### DIFF
--- a/control/controller.go
+++ b/control/controller.go
@@ -73,6 +73,14 @@ func (c *Controller) response(req *Request, subject string, body string) *mailer
 	mail := c.nl.DefaultMail(subject, body)
 	mail.InReplyTo = fmt.Sprintf("<%s>", req.MessageID)
 	mail.To = req.From.Address
+
+	referencesBuilder := strings.Builder{}
+	for _, id := range req.Headers.References {
+		fmt.Fprintf(&referencesBuilder, "<%s> ", id)
+	}
+	fmt.Fprintf(&referencesBuilder, "<%s>", req.MessageID)
+	mail.References = referencesBuilder.String()
+
 	return mail
 }
 

--- a/control/controller_test.go
+++ b/control/controller_test.go
@@ -103,6 +103,7 @@ Subject: Subscribe
 				To:              "test@club1.fr",
 				Id:              "<user-NRGABAKKE6AKVXM5S7IJQOUFFOXC2B3UF5QWX5VYFAKBRNWHZBHQ====@club1.fr>",
 				InReplyTo:       "<fakeid@club1.fr>",
+				References:      "<fakeid@club1.fr>",
 				ReplyTo:         "user+subscribe-confirm@club1.fr",
 				ListUnsubscribe: "<mailto:user+unsubscribe@club1.fr>",
 				Subject:         "[Title] Please confirm your subsciption",
@@ -122,6 +123,7 @@ Subject: Subscribe
 				FromName:        "Display Name",
 				To:              "recipient@club1.fr",
 				InReplyTo:       "<fakeid@club1.fr>",
+				References:      "<fakeid@club1.fr>",
 				ListUnsubscribe: "<mailto:user+unsubscribe@club1.fr>",
 				Subject:         "[Title] Already subscribed",
 				Body:            "Your email is already subscribed, if problem persist, contact <postmaster@club1.fr>.\n\n-- \nBye bye",
@@ -133,6 +135,7 @@ Subject: Subscribe
 To: user+subscribe-confirm@club1.fr
 Message-Id: <fakeid2@club1.fr>
 In-Reply-To: <user-NRGABAKKE6AKVXM5S7IJQOUFFOXC2B3UF5QWX5VYFAKBRNWHZBHQ====@club1.fr>
+References: <user-NRGABAKKE6AKVXM5S7IJQOUFFOXC2B3UF5QWX5VYFAKBRNWHZBHQ====@club1.fr>
 Subject: Subscribe confirm
 `,
 			expectedAddrs: []string{"recipient@club1.fr", "test@club1.fr"},
@@ -141,6 +144,7 @@ Subject: Subscribe confirm
 				FromName:        "Display Name",
 				To:              "test@club1.fr",
 				InReplyTo:       "<fakeid2@club1.fr>",
+				References:      "<user-NRGABAKKE6AKVXM5S7IJQOUFFOXC2B3UF5QWX5VYFAKBRNWHZBHQ====@club1.fr> <fakeid2@club1.fr>",
 				ListUnsubscribe: "<mailto:user+unsubscribe@club1.fr>",
 				Subject:         "[Title] Subscription is successfull !",
 				Body:            "Your email has been successfully subscribed to the newsletter [Title].\n\n-- \nBye bye",
@@ -159,6 +163,7 @@ Subject: Unsubscribe
 				FromName:        "Display Name",
 				To:              "recipient@club1.fr",
 				InReplyTo:       "<fakeid@club1.fr>",
+				References:      "<fakeid@club1.fr>",
 				ListUnsubscribe: "<mailto:user+unsubscribe@club1.fr>",
 				Subject:         "[Title] Unsubscription is successfull",
 				Body:            "Your email has been successfully unsubscribed from the newsletter [Title].\n\n-- \nBye bye",
@@ -183,6 +188,7 @@ Content of the mail!
 				To:              "user@club1.fr",
 				Id:              "user-KAV4QKP2PFXLWHG5XM3E6X23PROVB5DGNDSABUPA6XQIODZDJ6UA====@club1.fr",
 				InReplyTo:       "", // FIXME: shouldn't it be in reply to our message ID?
+				References:      "", // FIXME: shouldn't it be in our message's thread?
 				ReplyTo:         "user+send-confirm@club1.fr",
 				ListUnsubscribe: "<mailto:user+unsubscribe@club1.fr>",
 				Subject:         "[Title] Send (preview)",
@@ -195,6 +201,7 @@ Content of the mail!
 To: user+send-confirm@club1.fr
 Message-Id: <fakeid2@club1.fr>
 In-Reply-To: <user-KAV4QKP2PFXLWHG5XM3E6X23PROVB5DGNDSABUPA6XQIODZDJ6UA====@club1.fr>
+References: <user-KAV4QKP2PFXLWHG5XM3E6X23PROVB5DGNDSABUPA6XQIODZDJ6UA====@club1.fr>
 Subject: Send confirm
 `,
 			tmp: map[string]string{

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -25,6 +25,7 @@ type Mail struct {
 	To              string
 	Id              string
 	InReplyTo       string
+	References      string
 	ReplyTo         string
 	ListUnsubscribe string
 	Subject         string

--- a/mailer/mailx.go
+++ b/mailer/mailx.go
@@ -64,6 +64,9 @@ func (m *mailxMailer) Send(mail *Mail) error {
 	if mail.InReplyTo != "" {
 		args = append(args, "-a", "In-Reply-To: "+mail.InReplyTo)
 	}
+	if mail.References != "" {
+		args = append(args, "-a", "References: "+mail.References)
+	}
 	if mail.ReplyTo != "" {
 		args = append(args, "-a", "Reply-To: "+mail.ReplyTo)
 	}

--- a/mailer/mailx_test.go
+++ b/mailer/mailx_test.go
@@ -65,6 +65,26 @@ func TestMailxFlags(t *testing.T) {
 				`-- test@gmail.com`,
 			},
 		},
+		{
+			"reply",
+			&Mail{
+				FromAddr:   "nouvelles@club1.fr",
+				FromName:   "Nouvelles de CLUB1",
+				To:         "test@gmail.com",
+				Subject:    "Le sujet",
+				InReplyTo:  "<test-id2@club1.fr>",
+				References: "<test-id1@club1.fr> <test-id2@club1.fr>",
+			},
+			[]string{
+				`-s Le\\ sujet`,
+				`-r Nouvelles\\ de\\ CLUB1\\ \\<nouvelles@club1.fr\\>`,
+				`-a Content-Transfer-Encoding:\\ quoted-printable`,
+				`-a Content-Type:\\ text/plain\\;\\ charset=UTF-8`,
+				`-a In-Reply-To:\\ \\<test-id2@club1.fr\\>`,
+				`-a References:\\ \\<test-id1@club1.fr\\>\\ \\<test-id2@club1.fr\\>`,
+				`-- test@gmail.com`,
+			},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
Add the References: field to the header of reply emails so that clients can understand that it is part of a thread.

Fixes #2
