### PR TITLE
add list id header

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@ Newsletter-Go
 
 A very basic newsletter program for POSIX servers.
 
-It allow local server users to send a newsletter with their own email address to a list of subscribers.
+It allows local server users to send a newsletter with their own email address to a list of subscribers.
+It supports automatic (un)subscription via email and implements [RFC2369] and [RFC2919].
 
-It was designed for [CLUB1 community server](https://club1.fr/english), but may be usable by other UNIX-like servers (like *tilde* servers).
+It was designed for [CLUB1 community server](https://club1.fr/english),
+but may be usable by other UNIX-like servers (like *tilde* servers).
 
-The design strategy of this piece of code is to take advantage of Sendmail-style `.forward` files combined with recipient delimiter (`+` addresses). On CLUB1's server, we use it with Postfix ([man](https://www.postfix.org/local.8.html)).
+The design strategy of this piece of code is to take advantage of
+Sendmail-style `.forward` files combined with recipient delimiter (`+` addresses).
+On CLUB1's server, we use it with Postfix ([man](https://www.postfix.org/local.8.html)).
 
 This is a rewrite of the previous Bash version <https://github.com/club-1/newsletter> in Go.
 
@@ -113,6 +117,8 @@ Deployment will create:
     sbin/newsletterctl
 
 
+[RFC2369]: https://datatracker.ietf.org/doc/html/rfc2369
+[RFC2919]: https://datatracker.ietf.org/doc/html/rfc2919
 [build-svg]: https://github.com/club-1/newsletter-go/actions/workflows/build.yml/badge.svg
 [build-url]: https://github.com/club-1/newsletter-go/actions/workflows/build.yml
 [cover-svg]: https://github.com/club-1/newsletter-go/wiki/coverage.svg

--- a/control/controller_test.go
+++ b/control/controller_test.go
@@ -104,6 +104,7 @@ Subject: Subscribe
 				InReplyTo:       "<fakeid@club1.fr>",
 				References:      "<fakeid@club1.fr>",
 				ReplyTo:         "user+subscribe-confirm@club1.fr",
+				ListId:          `"Display Name" <user.club1.fr>`,
 				ListUnsubscribe: "<mailto:user+unsubscribe@club1.fr>",
 				Subject:         "[Title] Please confirm your subsciption",
 				Body:            "Reply to this email to confirm that you want to subscribe to the newsletter [Title] (the content does not matter).\n\n-- \nBye bye",
@@ -122,6 +123,7 @@ Subject: Subscribe
 				To:              "recipient@club1.fr",
 				InReplyTo:       "<fakeid@club1.fr>",
 				References:      "<fakeid@club1.fr>",
+				ListId:          `"Display Name" <user.club1.fr>`,
 				ListUnsubscribe: "<mailto:user+unsubscribe@club1.fr>",
 				Subject:         "[Title] Already subscribed",
 				Body:            "Your email is already subscribed, if problem persist, contact <postmaster@club1.fr>.\n\n-- \nBye bye",
@@ -142,6 +144,7 @@ Subject: Subscribe confirm
 				To:              "test@club1.fr",
 				InReplyTo:       "<fakeid2@club1.fr>",
 				References:      "<user-NRGABAKKE6AKVXM5S7IJQOUFFOXC2B3UF5QWX5VYFAKBRNWHZBHQ====@club1.fr> <fakeid2@club1.fr>",
+				ListId:          `"Display Name" <user.club1.fr>`,
 				ListUnsubscribe: "<mailto:user+unsubscribe@club1.fr>",
 				Subject:         "[Title] Subscription is successfull !",
 				Body:            "Your email has been successfully subscribed to the newsletter [Title].\n\n-- \nBye bye",
@@ -160,6 +163,7 @@ Subject: Unsubscribe
 				To:              "recipient@club1.fr",
 				InReplyTo:       "<fakeid@club1.fr>",
 				References:      "<fakeid@club1.fr>",
+				ListId:          `"Display Name" <user.club1.fr>`,
 				ListUnsubscribe: "<mailto:user+unsubscribe@club1.fr>",
 				Subject:         "[Title] Unsubscription is successfull",
 				Body:            "Your email has been successfully unsubscribed from the newsletter [Title].\n\n-- \nBye bye",
@@ -185,6 +189,7 @@ Content of the mail!
 				InReplyTo:       "", // FIXME: shouldn't it be in reply to our message ID?
 				References:      "", // FIXME: shouldn't it be in our message's thread?
 				ReplyTo:         "user+send-confirm@club1.fr",
+				ListId:          `"Display Name" <user.club1.fr>`,
 				ListUnsubscribe: "<mailto:user+unsubscribe@club1.fr>",
 				Subject:         "[Title] Send (preview)",
 				Body:            "Content of the mail!\n\n-- \nBye bye\n\nTo unsubscribe, send a mail to <user+unsubscribe@club1.fr>\n\n(this is a preview mail, if you want to confirm and send the newsletter to all the 1 subscribers, reply to this email)",
@@ -206,6 +211,7 @@ Subject: Send confirm
 			expectedMails: []mailer.Mail{{
 				From:            "Display Name <user@club1.fr>",
 				To:              "recipient@club1.fr",
+				ListId:          `"Display Name" <user.club1.fr>`,
 				ListUnsubscribe: "<mailto:user+unsubscribe@club1.fr>",
 				Subject:         "[Title] Send",
 				Body:            "Content of the mail!\n\n-- \nBye bye\n\nTo unsubscribe, send a mail to <user+unsubscribe@club1.fr>",

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -26,6 +26,7 @@ type Mail struct {
 	InReplyTo       string
 	References      string
 	ReplyTo         string
+	ListId          string
 	ListUnsubscribe string
 	Subject         string
 	Body            string

--- a/mailer/mailx.go
+++ b/mailer/mailx.go
@@ -67,6 +67,7 @@ func (m *mailxMailer) Send(mail *Mail) error {
 		{"In-Reply-To", mail.InReplyTo},
 		{"References", mail.References},
 		{"Reply-To", mail.ReplyTo},
+		{"List-Id", mail.ListId},
 		{"List-Unsubscribe", mail.ListUnsubscribe},
 	}
 	for _, header := range headers {

--- a/newsletter.go
+++ b/newsletter.go
@@ -99,6 +99,10 @@ func (nl *Newsletter) FromHdr() string {
 	}
 }
 
+func (nl *Newsletter) ListIdHdr() string {
+	return fmt.Sprintf(`%q <%s.%s>`, nl.Config.Settings.DisplayName, nl.LocalUser, nl.Hostname)
+}
+
 func (nl *Newsletter) UnsubscribeAddr() string {
 	return nl.LocalUser + "+" + RouteUnSubscribe + "@" + nl.Hostname
 }
@@ -127,6 +131,7 @@ func (nl *Newsletter) DefaultMail(subject string, body string) *mailer.Mail {
 
 	return &mailer.Mail{
 		From:            nl.FromHdr(),
+		ListId:          nl.ListIdHdr(),
 		ListUnsubscribe: nl.ListUnsubscribeHdr(),
 		Subject:         subject,
 		Body:            body,

--- a/newsletter_test.go
+++ b/newsletter_test.go
@@ -87,6 +87,7 @@ func TestDefaultMail(t *testing.T) {
 	mail := nl.DefaultMail("Test subject", "Mail body")
 	expected := &mailer.Mail{
 		From:            "Display Name <user@club1.fr>",
+		ListId:          `"Display Name" <user.club1.fr>`,
 		ListUnsubscribe: "<mailto:user+unsubscribe@club1.fr>",
 		Subject:         "[Title] Test subject",
 		Body: `Mail body


### PR DESCRIPTION
- **all: add List-Id header field to newsletter mails**
- **docs: add a quick sentence for the main features**

Fixes: #21 